### PR TITLE
update MOM6 in interface

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/MOM6"]
 	path = src/MOM6
-	url = https://github.com/NOAA-EMC/MOM6
+	url = https://github.com/DeniseWorthen/MOM6
 [submodule "src/mkmf"]
 	path = src/mkmf
 	url = https://github.com/NOAA-EMC/mkmf

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/MOM6"]
 	path = src/MOM6
-	url = https://github.com/DeniseWorthen/MOM6
+	url = https://github.com/NOAA-EMC/MOM6
 [submodule "src/mkmf"]
 	path = src/mkmf
 	url = https://github.com/NOAA-EMC/mkmf


### PR DESCRIPTION
Updates MOM6-interface to latest MOM6 commit. S2S is no longer using this submodule, but I need it to update the DATM app prior to moving to cmeps+cice6.